### PR TITLE
fix: make sure operation ids are unique #12

### DIFF
--- a/src/Generator/OperationCreator.php
+++ b/src/Generator/OperationCreator.php
@@ -20,7 +20,7 @@ class OperationCreator
     public function create(
         string $method,
         string $entity,
-        string $resource,
+        string $operationId,
         Responses $responses,
         ?RequestBody $requestBody = null,
         ?array $parameters = null,
@@ -31,7 +31,7 @@ class OperationCreator
             'tags' => [
                 $entity,
             ],
-            'operationId' => "{$method}{$resource}",
+            'operationId' => $operationId,
         ];
 
         if ($requestBody) {

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -3,8 +3,10 @@
 namespace Intermax\LaravelOpenApi\Tests;
 
 use Illuminate\Routing\Router;
+use Illuminate\Support\Arr;
 use Intermax\LaravelOpenApi\Generator\Generator;
 use Intermax\LaravelOpenApi\OpenApiServiceProvider;
+use Intermax\LaravelOpenApi\Tests\Utilities\ResourceInput\PetController;
 use Intermax\LaravelOpenApi\Tests\Utilities\ResourceInput\ThingController;
 use Orchestra\Testbench\TestCase;
 
@@ -31,7 +33,31 @@ class GeneratorTest extends TestCase
 
         $this->assertNotNull($spec['paths']['/things']['post'] ?? null);
 
-        $this->assertEquals('postThingResource', $spec['paths']['/things']['post']['operationId'] ?? null);
+        $this->assertEquals('postThings', $spec['paths']['/things']['post']['operationId'] ?? null);
+    }
+
+    /**
+     * @test
+     */
+    public function it_generates_distinct_operation_ids_with_nested_routes()
+    {
+        /** @var Generator $generator */
+        $generator = app(Generator::class);
+        $spec = json_decode($generator->generate(), true);
+
+        $this->assertEquals('postPets', Arr::get($spec, 'paths./pets.post.operationId'));
+        $this->assertEquals('postPetOwner', Arr::get($spec, 'paths./pets/{pet}/owner.post.operationId'));
+    }
+
+    /** @test */
+    public function it_generates_distinct_get_operation_ids()
+    {
+        /** @var Generator $generator */
+        $generator = app(Generator::class);
+        $spec = json_decode($generator->generate(), true);
+
+        $this->assertEquals('getPet', Arr::get($spec, 'paths./pets/{pet}.get.operationId'));
+        $this->assertEquals('getPets', Arr::get($spec, 'paths./pets.get.operationId'));
     }
 
     /**
@@ -42,6 +68,13 @@ class GeneratorTest extends TestCase
     {
         $router->middleware(['api'])->group(function ($router) {
             $router->apiResource('things', ThingController::class)->only('store');
+
+            $router->post('pets', [PetController::class, 'store']);
+
+            $router->post('pets/{pet}/owner', [PetController::class, 'storeOwner']);
+
+            $router->get('pets/{pet}', [PetController::class, 'show']);
+            $router->get('pets', [PetController::class, 'index']);
         });
     }
 }

--- a/tests/Utilities/ResourceInput/PetController.php
+++ b/tests/Utilities/ResourceInput/PetController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intermax\LaravelOpenApi\Tests\Utilities\ResourceInput;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Response;
+
+class PetController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return Response::json('success');
+    }
+
+    public function show(): JsonResponse
+    {
+        return Response::json('success');
+    }
+
+    public function store(): JsonResponse
+    {
+        return Response::json('success');
+    }
+
+    public function storeOwner(): JsonResponse
+    {
+        return Response::json('success');
+    }
+}


### PR DESCRIPTION
Currently it can happen that nested endpoints get the same operation id as their parent. This breaks swagger ui.